### PR TITLE
Aspiration depth decreased when aspiration bounds fail

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -829,6 +829,9 @@ SCORE_TYPE aspiration_window(Engine& engine, Position& position, SCORE_TYPE prev
             beta  = (alpha + 3 * beta) / 4;
             depth = engine.current_search_depth;
 
+            asp_depth--;
+            asp_depth = std::max<PLY_TYPE>(6, asp_depth);
+
             if (depth >= 12) print_thinking(engine, position, Lower_Node, return_eval);
         }
 
@@ -839,6 +842,9 @@ SCORE_TYPE aspiration_window(Engine& engine, Position& position, SCORE_TYPE prev
             beta  = std::min(beta + delta, SCORE_INF);
             depth = std::max(engine.min_depth,
                              static_cast<PLY_TYPE>(static_cast<int>(depth) - (return_eval < MATE_BOUND)));
+
+            asp_depth--;
+            asp_depth = std::max<PLY_TYPE>(6, asp_depth);
 
             if (depth >= 12) print_thinking(engine, position, Upper_Node, return_eval);
         }


### PR DESCRIPTION
```
ELO   | 1.30 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 65800 W: 19252 L: 19006 D: 27542
```
Bench: 8205216