### PR TITLE
Stronger NMP conditions to prevent against zugzwang

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -484,7 +484,7 @@ SCORE_TYPE negamax(Engine& engine, Position& position, SCORE_TYPE alpha, SCORE_T
         // We give the opponent an extra move and if they are not able to make their position
         // any better, then our position is too good, and we don't need to search any deeper.
         if (depth >= engine.tuning_parameters.NMP_depth && do_null && static_eval >= beta &&
-            position.non_pawn_material_count >= (depth >= 6)) {
+            position.non_pawn_material_count >= 1 + (depth >= 10)) {
 
             // Adaptive NMP
             int reduction = engine.tuning_parameters.NMP_base +


### PR DESCRIPTION
```
ELO   | 3.37 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 38936 W: 11393 L: 11015 D: 16528
```
Bench: 7983218