### PR TITLE
remove razoring

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -467,16 +467,6 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             return static_eval;
         }
 
-        // Razoring
-        // If the evaluation is really low, and we cannot improve alpha even with qsearch, then return.
-        // If the evaluation is improving then increase the margin because we are less certain that the
-        // position is terrible.
-        constexpr int razoring_margins[3] = {0, 320, 800};
-        if (depth <= 2 && static_eval + razoring_margins[depth] + improving * 120 < alpha) {
-            SCORE_TYPE return_eval = qsearch(engine, alpha, beta, engine.max_q_depth, thread_id);
-            if (return_eval < alpha) return return_eval;
-        }
-
         // Null move pruning
         // We give the opponent an extra move and if they are not able to make their position
         // any better, then our position is too good, and we don't need to search any deeper.


### PR DESCRIPTION
```
ELO   | 3.65 +- 5.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 1.00]
GAMES | N: 7896 W: 2248 L: 2165 D: 3483
```
Bench: 15448143