### PR TITLE
Negative Extensions

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -624,6 +624,10 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
                 return singular_beta;
             }
 
+            else if (tt_entry.score >= beta) {
+                extension--;
+            }
+
             position.make_move(move, thread_state.search_ply, thread_state.fifty_move);
         }
 


### PR DESCRIPTION
```
ELO   | 3.50 +- 2.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 33392 W: 9500 L: 9164 D: 14728
```
Bench: 15308682