### PR TITLE
fix se

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -847,9 +847,11 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
 
     engine.tt_prefetch_write(position.hash_key);
 
-    if (legal_moves == 0 && !in_check) return 0;
-    else if (legal_moves == 0) return -MATE_SCORE + thread_state.search_ply;
-
+    if (legal_moves == 0) {
+        if (singular_search) return alpha;
+        if (!in_check) return 0;
+        else return -MATE_SCORE + thread_state.search_ply;
+    }
 
     engine.record_tt_entry(thread_id, position.hash_key, best_score, tt_hash_flag, best_move, depth, static_eval);
 


### PR DESCRIPTION
```
ELO   | 1.93 +- 3.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.10 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 23032 W: 6465 L: 6337 D: 10230
```
Bench: 14987137