### PR TITLE
more history scores for pv or improving nodes

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -748,7 +748,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
                 tt_hash_flag = HASH_FLAG_EXACT;
 
                 // History Heuristic for move ordering
-                SCORE_TYPE bonus = depth * (depth + 1 + null_search) - 1;
+                SCORE_TYPE bonus = depth * (depth + 1 + null_search + pv_node + improving) - 1;
 
                 if (quiet) {
                     update_history_entry(thread_state.history_moves


### PR DESCRIPTION
```
ELO   | 1.64 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.61 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 73928 W: 20668 L: 20319 D: 32941
```
Bench: 14168483