### PR TITLE
Allow reductions while in check but less aggressive

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -665,7 +665,6 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             && ((thread_state.search_ply && !pv_node) || legal_moves >= 4)
             && depth >= 3
             && (quiet || bad_capture)
-            && !in_check
             ){
 
             reduction = quiet ?
@@ -679,6 +678,8 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             reduction -= is_killer_move * 0.75;
 
             reduction -= move_gives_check * 0.6;
+
+            reduction -= in_check;
 
             reduction -= move_history_score > 0 ? move_history_score / 7200.0 : move_history_score / 16000.0;
 


### PR DESCRIPTION
```
ELO   | 12.90 +- 7.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4472 W: 1295 L: 1129 D: 2048
```
Bench: 13865846