### PR TITLE
Let quiet LMP break out of the move loop

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -603,7 +603,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
                 legal_moves >= depth * engine.tuning_parameters.LMP_margin) break;
 
             // Quiet Late Move Pruning
-            if (quiet && legal_moves >= 2 + depth * depth / (1 + !improving + failing)) continue;
+            if (quiet && legal_moves >= 2 + depth * depth / (1 + !improving + failing)) break;
 
             // Futility Pruning
             if (quiet && depth <= 5 && static_eval + (depth - !improving) * 140 + 70 <= alpha) break;


### PR DESCRIPTION
```
ELO   | 12.97 +- 7.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4448 W: 1291 L: 1125 D: 2032
https://chess.swehosting.se/test/1943/
```
Bench: 11841540