### PR TITLE
scale TM by score changes

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -1103,6 +1103,8 @@ void iterative_search(Engine& engine, int thread_id) {
     uint64_t original_soft_time_limit = engine.soft_time_limit;
     MOVE_TYPE best_move = NO_MOVE;
 
+    SCORE_TYPE low_depth_score = 0;
+
     while (running_depth <= engine.max_depth) {
         thread_state.current_search_depth = running_depth;
         position.clear_state_stack();
@@ -1114,6 +1116,8 @@ void iterative_search(Engine& engine, int thread_id) {
         if (thread_id == 0 && !engine.stopped) best_move = engine.pv_table[0][0];
 
         if (thread_id == 0) {
+            if (running_depth <= 4) low_depth_score = previous_score;
+
             if (running_depth >= 8) {
                 auto best_node_percentage =
                         static_cast<double>(engine.node_table[get_selected(best_move)]
@@ -1122,7 +1126,16 @@ void iterative_search(Engine& engine, int thread_id) {
 
                 double node_scaling_factor = (1.5 - best_node_percentage) * 1.35;
 
-                engine.soft_time_limit = static_cast<uint64_t>(static_cast<double>(original_soft_time_limit) * node_scaling_factor);
+                SCORE_TYPE score_difference = previous_score - low_depth_score;
+                score_difference = std::clamp(score_difference, -120, 120);
+
+                double score_scaling_factor = 1.05 - (score_difference / 270.0);
+                //std::cout << previous_score - low_depth_score << " " << score_difference << std::endl;
+                //std::cout << score_scaling_factor << std::endl;
+
+                engine.soft_time_limit = static_cast<uint64_t>(static_cast<double>(original_soft_time_limit)
+                        * node_scaling_factor
+                        * score_scaling_factor);
 
                 // std::cout << "Soft Time Limit changed to: " << engine.soft_time_limit << std::endl;
             }


### PR DESCRIPTION
```
ELO   | 5.45 +- 4.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14080 W: 3911 L: 3690 D: 6479
https://chess.swehosting.se/test/2279/
```
Bench: 12612058