### PR TITLE
move ordering changes

### DIFF
--- a/search.h
+++ b/search.h
@@ -92,13 +92,13 @@ struct Tuning_Parameters {
 
 struct Move_Ordering_Parameters {
     T tuning_parameter_array[8] = {
-            T{"winning_capture_margin", 5000, 50000, 20000, 1750},
-            T{"base_capture_margin", -10000, 8000, 0, 2000},
-            T{"capture_scale", 1, 20, 2, 2},
-            T{"queen_promotion_margin", 20000, 50000, 30000, 1500},
-            T{"other_promotion_margin", -20000, 10000, -2000, 2000},
-            T{"first_killer_margin", 5000, 25000, 12000, 1000},
-            T{"second_killer_margin", 1000, 20000, 11000, 1500},
+            T{"winning_capture_margin", 5000, 50000, 50000, 1750},
+            T{"base_capture_margin", -10000, 8000, -500, 2000},
+            T{"capture_scale", 1, 20, 3, 2},
+            T{"queen_promotion_margin", 20000, 200000, 100000, 1500},
+            T{"other_promotion_margin", -20000, 10000, -30000, 2000},
+            T{"first_killer_margin", 5000, 50000, 30000, 1000},
+            T{"second_killer_margin", 1000, 49000, 25000, 1500},
             T{"castle_margin", 0, 2000, 1200, 200},
     };
 


### PR DESCRIPTION
```
ELO   | 4.80 +- 3.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 17792 W: 5130 L: 4884 D: 7778
https://chess.swehosting.se/test/2372/
```
Bench: 11844340