### PR TITLE
OCB evaluation

### DIFF
--- a/evaluation.cpp
+++ b/evaluation.cpp
@@ -101,6 +101,7 @@ SCORE_TYPE evaluate_pawns(Position& position, Color color, EvaluationInformation
 			auto protectors = popcount(evaluation_information.pawns[color] & get_piece_attacks(get_piece(PAWN, ~color), square, 0));
 
             score += PASSED_PAWN_BONUSES[protectors][relative_rank];
+            evaluation_information.passed_pawn_count[color]++;
 
             // BLOCKERS
             auto blocker_square = square + up;
@@ -240,7 +241,7 @@ SCORE_TYPE evaluate_pieces(Position& position, EvaluationInformation& evaluation
 }
 
 
-double evaluate_drawishness(EvaluationInformation& evaluation_information) {
+double evaluate_drawishness(Position& position, EvaluationInformation& evaluation_information) {
 
     // This function returns a decimal from 0.0 - 1.0 that will be used to scale the total evaluation
 
@@ -282,6 +283,59 @@ double evaluate_drawishness(EvaluationInformation& evaluation_information) {
 
     // There are pawns on the board
     if (evaluation_information.piece_counts[WHITE][PAWN] + evaluation_information.piece_counts[BLACK][PAWN] >= 1) {
+
+        // OCB endgames
+        bool opposite_colored_bishops = evaluation_information.piece_counts[WHITE][BISHOP] == 1 &&
+                                        evaluation_information.piece_counts[BLACK][BISHOP] == 1 &&
+                                        !same_color(static_cast<Square>(lsb(position.get_pieces(BISHOP, WHITE))),
+                                                    static_cast<Square>(lsb(position.get_pieces(BISHOP, BLACK))));
+
+        if (opposite_colored_bishops &&
+            evaluation_information.piece_counts[WHITE][KNIGHT] + evaluation_information.piece_counts[WHITE][ROOK] +
+            evaluation_information.piece_counts[BLACK][KNIGHT] + evaluation_information.piece_counts[BLACK][ROOK] == 0) {
+
+            Color more_pawns_side = (evaluation_information.piece_counts[WHITE][PAWN] >
+                                     evaluation_information.piece_counts[BLACK][PAWN]) ? WHITE : BLACK;
+
+            int pawn_difference = evaluation_information.piece_counts[more_pawns_side][PAWN] -
+                                  evaluation_information.piece_counts[~more_pawns_side][PAWN];
+
+            if (pawn_difference <= 1) return std::min(0.13 +
+                                                      evaluation_information.passed_pawn_count[more_pawns_side] *
+                                                      evaluation_information.passed_pawn_count[more_pawns_side] * 0.14, 1.0);
+
+            if (pawn_difference >= 3) return std::min(evaluation_information.passed_pawn_count[more_pawns_side] * 0.38
+                                                      + pawn_difference * 0.04, 1.0);
+
+            // Pawn Difference must equal two here
+            if (evaluation_information.passed_pawn_count[more_pawns_side] >= 3) return 1.0;
+
+            if (evaluation_information.piece_counts[more_pawns_side][PAWN] > 2)
+                return std::min(0.2 + evaluation_information.passed_pawn_count[more_pawns_side] *
+                                evaluation_information.passed_pawn_count[more_pawns_side] * 0.14, 1.0);
+
+            BITBOARD more_pawns_bitboard = position.get_pieces(PAWN, more_pawns_side);
+
+            // There are only two pawns here, and they must be passed
+            auto pawn_1 = static_cast<Square>(lsb(more_pawns_bitboard));
+            auto pawn_2 = static_cast<Square>(msb(more_pawns_bitboard));
+
+            int file_difference = abs(static_cast<int>(file_of(pawn_1)) - static_cast<int>(file_of(pawn_2))) - 1;
+            if (file_difference > 2) return 0.85;
+
+            if (file_difference == 1) return 0.1;
+            if (file_difference == 2) {
+                if (more_pawns_bitboard & (MASK_FILE[FILE_A] | MASK_FILE[FILE_H])) return 0.05;
+                if (more_pawns_bitboard & (MASK_FILE[FILE_B] | MASK_FILE[FILE_G])) return 0.15;
+                return 0.7;
+            }
+
+            // Pawns must be connected here
+            if (more_pawns_bitboard & (MASK_FILE[FILE_A] | MASK_FILE[FILE_H])) return 0.05;
+
+            return 0.15;
+        }
+
 
         if (more_material >= MAX_MINOR_PIECE_VALUE + CANONICAL_PIECE_VALUES[ROOK]) return 1.0;
 
@@ -370,7 +424,7 @@ SCORE_TYPE evaluate(Position& position) {
     SCORE_TYPE evaluation = (mg_score(score) * evaluation_information.game_phase +
             eg_score(score) * (24 - evaluation_information.game_phase)) / 24;
 
-    double drawishness = evaluate_drawishness(evaluation_information);
+    double drawishness = evaluate_drawishness(position, evaluation_information);
     evaluation = static_cast<SCORE_TYPE>(evaluation * drawishness);
 
     return (position.side * -2 + 1) * evaluation;

--- a/evaluation.h
+++ b/evaluation.h
@@ -12,6 +12,8 @@
 struct EvaluationInformation {
     int game_phase = 0;
 
+    int passed_pawn_count[2]{};
+
     int piece_counts[2][6]{};
 
     int total_king_ring_attacks[2]{};
@@ -34,7 +36,7 @@ SCORE_TYPE evaluate_king_pawn(const Position& position, File file, Color color, 
 SCORE_TYPE evaluate_piece(Position& position, PieceType piece_type, Color color, int& game_phase);
 SCORE_TYPE evaluate_pieces(Position& position, int& game_phase);
 
-double evaluate_drawishness(EvaluationInformation& evaluation_information);
+double evaluate_drawishness(Position& position, EvaluationInformation& evaluation_information);
 
 SCORE_TYPE evaluate(Position& position);
 
@@ -64,6 +66,10 @@ inline int mg_score(SCORE_TYPE s) {
 inline int get_manhattan_distance(Square square_1, Square square_2) {
     return abs(static_cast<int>(rank_of(square_1)) - static_cast<int>(rank_of(square_2))) +
            abs(static_cast<int>(file_of(square_1)) - static_cast<int>(file_of(square_2)));
+}
+
+inline bool same_color (Square square_1, Square square_2) {
+    return (( 9 * (square_1 ^ square_2)) & 8) == 0;
 }
 
 template<int n>


### PR DESCRIPTION
```
ELO   | 1.66 +- 5.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.12 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7328 W: 1937 L: 1902 D: 3489
https://chess.swehosting.se/test/2462/
```
Bench: 9008298