### PR TITLE
TT Fail low best move saving

### DIFF
--- a/search.cpp
+++ b/search.cpp
@@ -160,7 +160,10 @@ void Engine::record_tt_entry(int thread_id, HASH_TYPE hash_key, SCORE_TYPE score
         tt_entry.flag = tt_flag;
         tt_entry.score = score;
         tt_entry.evaluation = static_eval;
-        tt_entry.move = move;
+
+        if (tt_flag != HASH_FLAG_ALPHA || tt_entry.key != hash_key || tt_entry.move == NO_MOVE) {
+            tt_entry.move = move;
+        }
     }
 }
 
@@ -203,7 +206,10 @@ void Engine::record_tt_entry_q(int thread_id, HASH_TYPE hash_key, SCORE_TYPE sco
         tt_entry.flag = tt_flag;
         tt_entry.score = score;
         tt_entry.evaluation = static_eval;
-        tt_entry.move = move;
+
+        if (tt_flag != HASH_FLAG_ALPHA || tt_entry.key != hash_key || tt_entry.move == NO_MOVE) {
+            tt_entry.move = move;
+        }
     }
 }
 


### PR DESCRIPTION
```
ELO   | 10.44 +- 6.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5728 W: 1561 L: 1389 D: 2778
https://chess.swehosting.se/test/2722/
```
Bench: 7891339