### PR TITLE
Build natively, if native=1 is passed to make

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,6 +11,10 @@ CXXFLAGS     := -O3 -std=c++20 -Wall -Wextra -pedantic -DNDEBUG -flto
 CXX          := clang++
 SUFFIX       :=
 
+ifeq ($(native),1)
+    CXXFLAGS += -march=native
+endif
+
 # Detect Windows
 ifeq ($(OS), Windows_NT)
     SUFFIX   := .exe


### PR DESCRIPTION
Before
```
$ ./Altair bench |tail -1
9025695 nodes 1530557 nps
$ ./Altair bench |tail -1
9025695 nodes 1515904 nps
$ ./Altair bench |tail -1
9025695 nodes 1528224 nps
```

After
```
$ ./Altair bench |tail -1
9025695 nodes 1851424 nps
$ ./Altair bench |tail -1
9025695 nodes 1855230 nps
$ ./Altair bench |tail -1
9025695 nodes 1801895 np
```

