### PR TITLE
Base capture margin

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ endif
 ifeq ($(OS), Windows_NT)
     SUFFIX   := .exe
     CXXFLAGS += -static
-    CXXFLAGS += -fuse-ld=lld
+
 else
     DETECTED_OS := $(shell uname -s)
     ifneq (,$(findstring clang,$(shell $(CXX) --version)))

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ endif
 ifeq ($(OS), Windows_NT)
     SUFFIX   := .exe
     CXXFLAGS += -static
-
+    CXXFLAGS += -fuse-ld=lld
 else
     DETECTED_OS := $(shell uname -s)
     ifneq (,$(findstring clang,$(shell $(CXX) --version)))

--- a/src/constants.h
+++ b/src/constants.h
@@ -6,7 +6,7 @@
 #include "types.h"
 
 #define ENGINE_NAME                 "Altair"
-#define ENGINE_VERSION              "4.3.8"
+#define ENGINE_VERSION              "4.3.9"
 #define ENGINE_AUTHOR               "Alexander Tian"
 
 #define N_TUNING_PARAMETERS         18

--- a/src/search.h
+++ b/src/search.h
@@ -97,7 +97,7 @@ struct Tuning_Parameters {
 struct Move_Ordering_Parameters {
     T tuning_parameter_array[8] = {
             T{"winning_capture_margin", 5000, 50000, 50000, 1750},
-            T{"base_capture_margin", -10000, 8000, -500, 2000},
+            T{"base_capture_margin", -10000, 8000, -5000, 2000},
             T{"capture_scale", 1, 20, 3, 2},
             T{"queen_promotion_margin", 20000, 200000, 100000, 1500},
             T{"other_promotion_margin", -20000, 10000, -30000, 2000},

--- a/src/search.h
+++ b/src/search.h
@@ -97,7 +97,7 @@ struct Tuning_Parameters {
 struct Move_Ordering_Parameters {
     T tuning_parameter_array[8] = {
             T{"winning_capture_margin", 5000, 50000, 50000, 1750},
-            T{"base_capture_margin", -10000, 8000, -5000, 2000},
+            T{"base_capture_margin", -10000, 8000, -3000, 2000},
             T{"capture_scale", 1, 20, 3, 2},
             T{"queen_promotion_margin", 20000, 200000, 100000, 1500},
             T{"other_promotion_margin", -20000, 10000, -30000, 2000},


### PR DESCRIPTION
```
ELO: 1.89 +- 1.29 [0.607, 3.18]
LLR: 4.01 [0.0, 3.0] (-2.25, 2.89)
H1 Accepted
GAMES | N: 138192 W: 34571 L: 33822 D: 69799
https://chess.swehosting.se/test/3661/
```