### PR TITLE
Aggressive bad capture

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -813,6 +813,8 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             // Get the base reduction based on depth and moves searched
             reduction = engine.LMR_REDUCTIONS_QUIET[depth][std::min(legal_moves, 63)];
 
+            reduction -= !quiet;
+
             // Fewer reductions if we are in a pv node, since moves are likely to be better and more important
             reduction -= pv_node;
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -811,9 +811,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             ){
 
             // Get the base reduction based on depth and moves searched
-            reduction = quiet ?
-                    engine.LMR_REDUCTIONS_QUIET[depth][std::min(legal_moves, 63)] :
-                    engine.LMR_REDUCTIONS_NOISY[depth][std::min(legal_moves, 63)];
+            reduction = engine.LMR_REDUCTIONS_QUIET[depth][std::min(legal_moves, 63)];
 
             // Fewer reductions if we are in a pv node, since moves are likely to be better and more important
             reduction -= pv_node;


### PR DESCRIPTION
```
ELO   | 4.06 +- 3.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 21568 W: 5471 L: 5219 D: 10878
https://chess.swehosting.se/test/3871/
```