### PR TITLE
Index capture history by whether a move is winning or losing

### DIFF
--- a/src/move_ordering.cpp
+++ b/src/move_ordering.cpp
@@ -32,17 +32,16 @@ SCORE_TYPE score_move(Thread_State& thread_state, Move move, Move tt_move,
 
     if (move.is_capture(position)) {
         auto occupied_type = get_piece_type(occupied, ~position.side);
-        
-        score += thread_state.capture_history[selected][occupied][move.target()];
         score += thread_state.move_ordering_parameters.capture_scale * MVV_LVA_VALUES[occupied_type]
                 - MVV_LVA_VALUES[selected_type];
 
+        bool winning_capture = get_static_exchange_evaluation(position, move, SEE_MOVE_ORDERING_THRESHOLD);
+
+        score += thread_state.capture_history[winning_capture][selected][occupied][move.target()];
+
         // Only Use SEE under certain conditions since it is expensive
-        if (score >= -3000) {
-            if (score >= 3000 ||
-                get_static_exchange_evaluation(position, move, SEE_MOVE_ORDERING_THRESHOLD))
-                score += thread_state.move_ordering_parameters.winning_capture_margin;
-        }
+        if (winning_capture)
+            score += thread_state.move_ordering_parameters.winning_capture_margin;
 
         score += thread_state.move_ordering_parameters.base_capture_margin;
     }
@@ -84,12 +83,13 @@ SCORE_TYPE score_capture(Thread_State& thread_state, Move move, Move tt_move) {
     Piece selected = position.board[move.origin()];
     Piece occupied = position.board[move.target()];
 
-    score += thread_state.capture_history[selected][occupied][move.target()];
+    bool winning_capture = get_static_exchange_evaluation(position, move, SEE_MOVE_ORDERING_THRESHOLD);
 
-    if (score >= -3000) {
-        if (score >= 3000 || get_static_exchange_evaluation(position, move, SEE_MOVE_ORDERING_THRESHOLD))
-            score += thread_state.move_ordering_parameters.winning_capture_margin;
-    }
+    score += thread_state.capture_history[winning_capture][selected][occupied][move.target()];
+
+    // Only Use SEE under certain conditions since it is expensive
+    if (winning_capture)
+        score += thread_state.move_ordering_parameters.winning_capture_margin;
 
     if (selected < BLACK_PAWN) score += MVV_LVA_VALUES[occupied - BLACK_PAWN] - MVV_LVA_VALUES[selected];
     else score += MVV_LVA_VALUES[occupied] - MVV_LVA_VALUES[selected - BLACK_PAWN];

--- a/src/move_ordering.h
+++ b/src/move_ordering.h
@@ -7,7 +7,7 @@
 #include "search.h"
 #include "fixed_vector.h"
 
-constexpr SCORE_TYPE SEE_MOVE_ORDERING_THRESHOLD = -108;
+constexpr SCORE_TYPE SEE_MOVE_ORDERING_THRESHOLD = -85;
 
 SCORE_TYPE score_move(Thread_State& thread_state, Move move, Move tt_move,
                       InformativeMove last_move_one, InformativeMove last_move_two);

--- a/src/position.h
+++ b/src/position.h
@@ -14,6 +14,7 @@
 struct ScoredMove {
     Move move = NO_MOVE;
     SCORE_TYPE score = 0;
+    bool winning_capture = false;
 };
 
 struct State_Struct {

--- a/src/search.h
+++ b/src/search.h
@@ -134,7 +134,7 @@ public:
 
     InformativeMove killer_moves[2][MAX_AB_DEPTH]{};  // killer moves (2) | max_depth (64)
     SCORE_TYPE history_moves[12][64]{}; // piece | target_square
-    SCORE_TYPE capture_history[12][12][64]{};
+    SCORE_TYPE capture_history[2][12][12][64]{};
     SCORE_TYPE continuation_history[12][64][12][64]{};
 
     HASH_TYPE repetition_table[TOTAL_MAX_DEPTH + 512] = {0};
@@ -215,7 +215,8 @@ public:
 
 void update_history_entry(SCORE_TYPE& score, SCORE_TYPE bonus);
 void update_histories(Thread_State& thread_state, InformativeMove informative_move,
-                      InformativeMove last_move_one, InformativeMove last_move_two, bool quiet, int move_index, int bonus);
+                      InformativeMove last_move_one, InformativeMove last_move_two, bool quiet, bool winning_capture,
+                      int move_index, int bonus);
 
 SCORE_TYPE qsearch(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth, int thread_id);
 SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth,  bool do_null, int thread_id);


### PR DESCRIPTION
```
ELO   | 3.63 +- 2.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 27168 W: 6934 L: 6650 D: 13584
https://chess.swehosting.se/test/3942/
```
Free original idea
Bench: 8918856