### PR TITLE
Mvvlva

### DIFF
--- a/src/evaluation_constants.h
+++ b/src/evaluation_constants.h
@@ -8,7 +8,7 @@
 
 constexpr int GAME_PHASE_SCORES[6] = {0, 1, 1, 2, 4, 0};
 
-constexpr int MVV_LVA_VALUES[6] = {  87, 390, 429, 561, 1234,   0};
+constexpr int MVV_LVA_VALUES[6] = {  120, 430, 450, 620, 1400,   0};
 
 constexpr SCORE_TYPE CANONICAL_PIECE_VALUES[6] = {100, 310, 340, 500, 900, 0};
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -11,8 +11,8 @@
 
 #include "incbin.h"
 
-// INCBIN(nnue, "src/net-epoch55.bin");
-INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/net-epoch55.bin");
+INCBIN(nnue, "src/net-epoch55.bin");
+// INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/net-epoch55.bin");
 
 const NNUE_Params &nnue_parameters = *reinterpret_cast<const NNUE_Params *>(gnnueData);
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -11,8 +11,8 @@
 
 #include "incbin.h"
 
-INCBIN(nnue, "src/net-epoch55.bin");
-// INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/net-epoch55.bin");
+// INCBIN(nnue, "src/net-epoch55.bin");
+INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/net-epoch55.bin");
 
 const NNUE_Params &nnue_parameters = *reinterpret_cast<const NNUE_Params *>(gnnueData);
 

--- a/src/search.h
+++ b/src/search.h
@@ -46,7 +46,7 @@ struct Tuning_Parameters {
     T tuning_parameter_array[N_TUNING_PARAMETERS] = {
             T{"LMR_divisor_quiet", 150, 230, 185, 20},
             T{"LMR_base_quiet", 100, 170, 155, 20},
-            T{"delta_margin", 100, 400, 175, 40},
+            T{"delta_margin", 100, 400, 220, 40},
             T{"RFP_depth", 5, 11, 9, 2},
             T{"RFP_margin", 50, 200, 126, 30},
             T{"LMP_depth", 2, 4, 3, 1},


### PR DESCRIPTION
```
ELO   | 8.67 +- 5.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 6736 W: 1666 L: 1498 D: 3572
https://chess.swehosting.se/test/4363/
```