### PR TITLE
Cleanup lmr

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -11,8 +11,8 @@
 
 #include "incbin.h"
 
-// INCBIN(nnue, "src/net-epoch55.bin");
-INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/net-epoch55.bin");
+INCBIN(nnue, "src/net-epoch55.bin");
+// INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/net-epoch55.bin");
 
 const NNUE_Params &nnue_parameters = *reinterpret_cast<const NNUE_Params *>(gnnueData);
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -11,8 +11,8 @@
 
 #include "incbin.h"
 
-INCBIN(nnue, "src/net-epoch55.bin");
-// INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/net-epoch55.bin");
+// INCBIN(nnue, "src/net-epoch55.bin");
+INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/net-epoch55.bin");
 
 const NNUE_Params &nnue_parameters = *reinterpret_cast<const NNUE_Params *>(gnnueData);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -827,7 +827,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             reduction -= pv_node;
 
             // Fewer reductions when improving, since the current node and moves searched in it are more important
-            reduction -= improving * 0.9;
+            reduction -= improving;
             reduction += failing;
 
             // Fewer reductions for interesting moves which we define above


### PR DESCRIPTION
```
ELO   | 2.21 +- 2.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.80 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 31488 W: 7552 L: 7352 D: 16584
https://chess.swehosting.se/test/4390/
```

```
LLR: 3.93 [-3.0, 0.0] (-2.94, 2.94)
```
with regression/simplification bounds 
