### PR TITLE
SE params changed

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -763,16 +763,16 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
 
         // Checking for singularity
         if (!root &&
-            depth >= 8 &&
+            depth >= 6 &&
             move == tt_move &&
-            tt_entry.depth >= depth - 3 &&
+            tt_entry.depth >= depth - 2 &&
             tt_entry.flag != HASH_FLAG_ALPHA &&
             position.state_stack[thread_state.search_ply].excluded_move == NO_MOVE &&
             abs(tt_entry.score) < MATE_BOUND) {
 
             position.undo_move<NO_NNUE>(move, position.state_stack[thread_state.search_ply], thread_state.fifty_move);
 
-            int singular_beta = tt_entry.score - depth * 2;
+            int singular_beta = tt_entry.score - depth;
 
             thread_state.search_ply++;
 
@@ -786,7 +786,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             // Singular Extensions
             if (return_eval < singular_beta) {
                 extension++;
-                if (!pv_node && return_eval < singular_beta - 24) extension++;
+                if (!pv_node && return_eval < singular_beta - 16) extension++;
             }
 
             // Multi-cut Pruning


### PR DESCRIPTION
STC:
```
Elo   | -4.83 +- 8.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.55 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3452 W: 827 L: 875 D: 1750
Penta | [49, 429, 798, 421, 29]
```

LTC:
```
Elo   | 2.56 +- 3.40 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.80 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17940 W: 4089 L: 3957 D: 9894
Penta | [86, 2015, 4626, 2167, 76]
```

Merged for scaling as time control increases