### PR TITLE
Change extension handling

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -7,7 +7,7 @@
 #include "types.h"
 
 #define ENGINE_NAME                 "Altair"
-#define ENGINE_VERSION              "6.0.9"
+#define ENGINE_VERSION              "6.1.0"
 #define ENGINE_AUTHOR               "Alexander Tian"
 
 #define N_TUNING_PARAMETERS         19


### PR DESCRIPTION
STC
```
Elo   | 1.43 +- 1.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.05 (-2.25, 2.89) [0.00, 5.00]
Games | N: 73502 W: 18165 L: 17863 D: 37474
Penta | [825, 8731, 17312, 9083, 800]
```

LTC
```
Elo   | 5.65 +- 4.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8424 W: 1960 L: 1823 D: 4641
Penta | [32, 925, 2182, 1020, 53]
http://antares2262.pythonanywhere.com/test/32/
```

LTC pass
Bench: 6603776