### PR TITLE
Cutnode reductions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -501,7 +501,7 @@ template SCORE_TYPE qsearch<NO_NNUE >(Engine& engine, SCORE_TYPE alpha, SCORE_TY
 // This is a recursive search function based on the minimax algorithm that uses alpha-beta pruning
 // among other heuristics.
 template<bool NNUE>
-SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth, bool do_null, int thread_id) {
+SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth, bool do_null, bool cutnode, int thread_id) {
 
     // Initialize Variables
     Thread_State& thread_state = engine.thread_states[thread_id];
@@ -632,7 +632,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             thread_state.game_ply++;
 
             // zero window search with reduced depth
-            SCORE_TYPE return_eval = -negamax<NNUE>(engine, -beta, -beta + 1, depth - reduction, false, thread_id);
+            SCORE_TYPE return_eval = -negamax<NNUE>(engine, -beta, -beta + 1, depth - reduction, false, !cutnode, thread_id);
 
             thread_state.game_ply--;
             thread_state.search_ply--;
@@ -641,7 +641,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             if (return_eval >= beta) {
                 if (return_eval >= MATE_BOUND) return beta;
                 if (depth <= 15) return return_eval;
-                SCORE_TYPE verification_eval = negamax<NNUE>(engine, beta - 1, beta, depth - reduction, false, thread_id);
+                SCORE_TYPE verification_eval = negamax<NNUE>(engine, beta - 1, beta, depth - reduction, false, cutnode, thread_id);
                 if (verification_eval > beta) return return_eval;
             }
         }
@@ -778,7 +778,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
 
             position.state_stack[thread_state.search_ply].excluded_move = move;
             SCORE_TYPE return_eval = negamax<NNUE>(engine, singular_beta - 1, singular_beta, (depth - 1) / 2,
-                                                   false, thread_id);
+                                                   false, cutnode, thread_id);
             position.state_stack[thread_state.search_ply].excluded_move = NO_MOVE;
 
             thread_state.search_ply--;
@@ -870,12 +870,15 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             // My idea that in a null move search you can be more aggressive with LMR
             reduction += null_search;
 
+            // Reduce more on cutnodes
+            reduction += cutnode;
+
             // Clamp the LMR depth
             reduction = std::clamp<PLY_TYPE>(reduction, 0, new_depth - 1);
             auto lmr_depth = new_depth - reduction;
 
             // Recursively search
-            return_eval = -negamax<NNUE>(engine, -alpha - 1, -alpha, lmr_depth, true, thread_id);
+            return_eval = -negamax<NNUE>(engine, -alpha - 1, -alpha, lmr_depth, true, true, thread_id);
 
             // Check if we need to search at full depth with a zero window
             full_depth_zero_window = return_eval > alpha && lmr_depth != new_depth;
@@ -895,12 +898,12 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
                 new_depth -= return_eval <  best_score + new_depth; // Shallower Search
             }
 
-            return_eval = -negamax<NNUE>(engine, -alpha - 1, -alpha, new_depth, true, thread_id);
+            return_eval = -negamax<NNUE>(engine, -alpha - 1, -alpha, new_depth, true, !cutnode, thread_id);
         }
 
         // Search to a full depth at normal bounds if necessary
         if (return_eval == -SCORE_INF || (pv_node && ((return_eval > alpha && return_eval < beta) || legal_moves == 0))) {
-            return_eval = -negamax<NNUE>(engine, -beta, -alpha, new_depth, true, thread_id);
+            return_eval = -negamax<NNUE>(engine, -beta, -alpha, new_depth, true, false, thread_id);
         }
 
         // Undo the move and other changes
@@ -998,8 +1001,8 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
     return best_score;
 }
 
-template SCORE_TYPE negamax<USE_NNUE>(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth, bool do_null, int thread_id);
-template SCORE_TYPE negamax<NO_NNUE >(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth, bool do_null, int thread_id);
+template SCORE_TYPE negamax<USE_NNUE>(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth, bool do_null, bool cutnode, int thread_id);
+template SCORE_TYPE negamax<NO_NNUE >(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth, bool do_null, bool cutnode, int thread_id);
 
 
 void print_thinking(Engine& engine, NodeType node, SCORE_TYPE best_score, int pv_number, int thread_id) {
@@ -1108,7 +1111,7 @@ SCORE_TYPE aspiration_window(Engine& engine, SCORE_TYPE previous_score, PLY_TYPE
         if (alpha <= -1000) alpha = -SCORE_INF;
         if (beta  >=  1000) beta  =  SCORE_INF;
 
-        return_eval = negamax<NNUE>(engine, alpha, beta, depth, false, thread_id);
+        return_eval = negamax<NNUE>(engine, alpha, beta, depth, false, false, thread_id);
 
         if (engine.stopped) break;
 
@@ -1179,7 +1182,7 @@ SCORE_TYPE multi_pv_search(Engine& engine, SCORE_TYPE previous_score, PLY_TYPE& 
 
     int alternate_pvs = std::min(engine.multi_pv, static_cast<int>(engine.root_moves.size()));
     for (int i = 1; i < alternate_pvs; i++) {
-        int pv_score = negamax<NNUE>(engine, -SCORE_INF, SCORE_INF, depth, false, thread_id);
+        int pv_score = negamax<NNUE>(engine, -SCORE_INF, SCORE_INF, depth, false, false, thread_id);
         if (engine.stopped) break;
 
         if (thread_id == 0) print_thinking(engine, Exact_Node, pv_score, i, thread_id);

--- a/src/search.h
+++ b/src/search.h
@@ -257,7 +257,7 @@ void update_histories(Thread_State& thread_state, InformativeMove informative_mo
 template<bool NNUE>
 SCORE_TYPE qsearch(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth, int thread_id);
 template<bool NNUE>
-SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth,  bool do_null, int thread_id);
+SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE depth,  bool do_null, bool cutnode, int thread_id);
 
 void print_thinking(Engine& engine, NodeType node, SCORE_TYPE best_score, int pv_number, int thread_id);
 


### PR DESCRIPTION
```
Elo   | 1.90 +- 3.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.58 (-2.25, 2.89) [0.00, 5.00]
Games | N: 16808 W: 4176 L: 4084 D: 8548
Penta | [184, 1960, 4021, 2058, 181]

ELO: 1.9 +- 3.68 [-1.78, 5.58]
LLR: 3.17 [-4.0, 1.0] (-2.94, 2.94)
```

Merged for cutnode functionality and non-regression
Bench: 7579896