### PR TITLE
Negative Extensions on alpha condition in SE

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -794,7 +794,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
                 return singular_beta;
             }
 
-            else if (tt_entry.score >= beta) {
+            else if (tt_entry.score >= beta || tt_entry.score <= alpha) {
                 extension--;
             }
 


### PR DESCRIPTION
```
Elo   | 4.71 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13132 W: 3404 L: 3226 D: 6502
Penta | [172, 1489, 3081, 1637, 187]
http://antares2262.pythonanywhere.com/test/60/
```