### PR TITLE
move IIR after forward pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -597,12 +597,6 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
         }
     }
 
-    // Internal Iterative Reduction. Based on Rebel's idea
-    if (tt_move == NO_MOVE && !singular_search && depth >= 4) {
-        depth--;
-        if (pv_node) depth--;
-    }
-
     // Forward Pruning Methods
     if (!pv_node && !in_check && !singular_search && abs(beta) < MATE_BOUND) {
 
@@ -645,6 +639,12 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
                 if (verification_eval > beta) return return_eval;
             }
         }
+    }
+
+    // Internal Iterative Reduction. Based on Rebel's idea
+    if (tt_move == NO_MOVE && depth >= 4) {
+        depth--;
+        if (pv_node) depth--;
     }
 
     bool tt_move_capture = tt_move.is_capture(position);


### PR DESCRIPTION
```
Elo   | 3.41 +- 3.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 20288 W: 5088 L: 4889 D: 10311
Penta | [196, 2400, 4810, 2485, 253]
http://antares2262.pythonanywhere.com/test/68/
```
Bench: 6840903