### PR TITLE
Reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -865,7 +865,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
         // Late Move Reductions (LMR)
         // The idea that if moves are ordered well, then moves that are searched
         // later shouldn't be as good, and therefore we don't need to search them to a very high depth
-        if (legal_moves >= 2 + 2 * root + pv_node
+        if (legal_moves >= 2 + pv_node
             && depth >= 3
             && (quiet || !winning_capture)
             ){
@@ -930,7 +930,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
 
         // Search to a full depth at normal bounds if necessary
         if (return_eval == -SCORE_INF || (pv_node && ((return_eval > alpha && return_eval < beta) || legal_moves == 0))) {
-            return_eval = -negamax<NNUE>(engine, -beta, -alpha, new_depth - (reduction > 3), true, false, thread_id);
+            return_eval = -negamax<NNUE>(engine, -beta, -alpha, new_depth, true, false, thread_id);
         }
 
         // Undo the move and other changes

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -859,7 +859,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
 
         uint64_t current_nodes = thread_state.node_count;
 
-        int reduction;
+        int reduction = 0;
         bool full_depth_zero_window;
 
         // Late Move Reductions (LMR)
@@ -930,7 +930,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
 
         // Search to a full depth at normal bounds if necessary
         if (return_eval == -SCORE_INF || (pv_node && ((return_eval > alpha && return_eval < beta) || legal_moves == 0))) {
-            return_eval = -negamax<NNUE>(engine, -beta, -alpha, new_depth, true, false, thread_id);
+            return_eval = -negamax<NNUE>(engine, -beta, -alpha, new_depth - (reduction > 3), true, false, thread_id);
         }
 
         // Undo the move and other changes

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -865,7 +865,7 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
         // Late Move Reductions (LMR)
         // The idea that if moves are ordered well, then moves that are searched
         // later shouldn't be as good, and therefore we don't need to search them to a very high depth
-        if (legal_moves >= 2 + pv_node
+        if (legal_moves >= 1 + root + pv_node
             && depth >= 3
             && (quiet || !winning_capture)
             ){


### PR DESCRIPTION
```
Elo   | 3.43 +- 3.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19564 W: 4877 L: 4684 D: 10003
Penta | [173, 2248, 4754, 2427, 180]
https://chess.swehosting.se/test/5618/
```