### PR TITLE
Tm changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,6 @@ add_executable(Altair
         src/nnue.cpp
         src/nnue.h
         src/incbin.h
-        src/wdl.h src/simd.h)
+        src/wdl.h src/simd.h src/timeman.cpp src/timeman.h)
 
 target_link_libraries(Altair Threads::Threads)

--- a/makefile
+++ b/makefile
@@ -4,7 +4,7 @@ EXE      = Altair
 
 SOURCES      := src/evaluation.cpp src/main.cpp src/move.cpp src/perft.cpp src/position.cpp src/search.cpp \
 				src/useful.cpp src/uci.cpp src/bench.cpp src/see.cpp src/bitboard.cpp src/move_ordering.cpp \
-				src/datagen.cpp src/nnue.cpp
+				src/datagen.cpp src/nnue.cpp src/timeman.cpp
 
 CXXFLAGS     := -O3 -std=c++20 -march=native -Wall -Wextra -pedantic -DNDEBUG -flto
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -12,8 +12,8 @@
 
 #include "incbin.h"
 
-INCBIN(nnue, "src/europa-net.bin");
-// INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/europa-net.bin");
+// INCBIN(nnue, "src/europa-net.bin");
+INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/europa-net.bin");
 
 const NNUE_Params &original_nnue_parameters = *reinterpret_cast<const NNUE_Params *>(gnnueData);
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -12,8 +12,8 @@
 
 #include "incbin.h"
 
-// INCBIN(nnue, "src/europa-net.bin");
-INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/europa-net.bin");
+INCBIN(nnue, "src/europa-net.bin");
+// INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/europa-net.bin");
 
 const NNUE_Params &original_nnue_parameters = *reinterpret_cast<const NNUE_Params *>(gnnueData);
 

--- a/src/search.h
+++ b/src/search.h
@@ -184,7 +184,7 @@ public:
     PLY_TYPE max_q_depth = TOTAL_MAX_DEPTH - MAX_AB_DEPTH;
     PLY_TYPE min_depth = 1;
 
-    int move_overhead = 10;
+    int move_overhead = 50;
     uint64_t hard_time_limit = 60000;
     uint64_t soft_time_limit = 60000;
     uint64_t start_time = 0;

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -67,7 +67,7 @@ double position_time_scale(Position& position) {
 void time_handler(Engine& engine, double self_time, double inc, double movetime, long movestogo) {
     double time_amt;
 
-    double movestogo_ratio = movestogo == 0 ? 0 : std::clamp(std::asin((movestogo + 14) / 18.0), 0.75, 1.05);
+    double movestogo_ratio = movestogo == 0 ? 0 : std::clamp(std::atan((movestogo + 14) / 18.0), 0.75, 1.05);
 
     Position& position = engine.thread_states[0].position;
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -87,10 +87,12 @@ void time_handler(Engine& engine, double self_time, double inc, double movetime,
     }
 
     if (movestogo > 0 && inc == 0) {
-        time_amt = self_time * 0.9 / static_cast<double>(movestogo);
-        if (time_amt > self_time * 0.9) time_amt = self_time * 0.95;
+        time_amt = self_time * 0.95 / static_cast<double>(movestogo);
+        if (time_amt > self_time * 0.95) time_amt = self_time * 0.95;
 
-        time_amt *= (0.6 + 0.4 * pts);
+        if (movestogo == 1) time_amt = self_time;
+        else time_amt *= (0.6 + 0.4 * pts);
+
         goto update;
     }
 
@@ -101,20 +103,25 @@ void time_handler(Engine& engine, double self_time, double inc, double movetime,
     }
 
     if (movestogo > 0 && inc > 0) {
-        time_amt = self_time * 0.9 / static_cast<double>(movestogo) + inc * 0.75;
-        if (time_amt > self_time * 0.9) time_amt = self_time * 0.85 + inc * 0.75;
+        time_amt = self_time * 0.95 / static_cast<double>(movestogo) + inc * 0.75;
+        if (time_amt > self_time * 0.95) time_amt = std::min(self_time * 0.85 + inc * 0.75, self_time * 0.95);
 
-        time_amt *= (0.6 + 0.4 * pts);
+        if (movestogo == 1) time_amt = self_time;
+        else time_amt *= (0.6 + 0.4 * pts);
+
         goto update;
     }
 
     time_amt = 100;
 
 update:
+
+    if (self_time) time_amt = std::min(time_amt, self_time * 0.95);
+
     engine.hard_time_limit = std::max(static_cast<uint64_t>(time_amt),
                                       static_cast<uint64_t>(time_amt * 2.64) - engine.move_overhead);
 
-    engine.soft_time_limit = static_cast<uint64_t>(time_amt * 0.76);
+    engine.soft_time_limit = std::min(static_cast<uint64_t>(time_amt * 0.76), static_cast<uint64_t>(self_time * 0.7));
 
     if (engine.hard_time_limit > static_cast<uint64_t>(self_time * 0.8) && self_time > 0) {
         engine.hard_time_limit = static_cast<uint64_t>(self_time * 0.8);
@@ -124,6 +131,6 @@ update:
         engine.hard_time_limit = static_cast<uint64_t>(time_amt);
     }
 
-    std::cout << engine.soft_time_limit << " " << engine.hard_time_limit << std::endl;
+    std::cout << time_amt << " " << engine.soft_time_limit << " " << engine.hard_time_limit << std::endl;
 }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -124,7 +124,7 @@ update:
     engine.hard_time_limit = std::max(static_cast<uint64_t>(time_amt),
                                       static_cast<uint64_t>(time_amt * 2.64) - engine.move_overhead);
 
-    engine.soft_time_limit = std::min(static_cast<uint64_t>(time_amt * 0.76), static_cast<uint64_t>(self_time * 0.7));
+    engine.soft_time_limit = std::min(static_cast<uint64_t>(time_amt * 0.76), static_cast<uint64_t>(self_time * 0.8));
 
     if (engine.hard_time_limit > static_cast<uint64_t>(self_time * 0.8) && self_time > 0) {
         engine.hard_time_limit = static_cast<uint64_t>(self_time * 0.8);

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -67,7 +67,7 @@ double position_time_scale(Position& position) {
 void time_handler(Engine& engine, double self_time, double inc, double movetime, long movestogo) {
     double time_amt;
 
-    double movestogo_ratio = movestogo == 0 ? 0 : std::clamp(std::atan((movestogo + 14) / 18.0), 0.75, 0.9);
+    double movestogo_ratio = movestogo == 0 ? 0 : std::clamp(std::atan((movestogo + 20) / 24.0), 0.84, 1.1);
 
     Position& position = engine.thread_states[0].position;
 
@@ -94,7 +94,7 @@ void time_handler(Engine& engine, double self_time, double inc, double movetime,
         if (time_amt > self_time * 0.9) time_amt = self_time * 0.9;
 
         if (movestogo == 1) time_amt = self_time * 0.9;
-        else time_amt *= (0.6 + 0.4 * pts);
+        else time_amt *= (0.7 + 0.3 * pts);
 
         goto update;
     }
@@ -110,7 +110,7 @@ void time_handler(Engine& engine, double self_time, double inc, double movetime,
         if (time_amt > self_time * 0.9) time_amt = std::min(self_time * 0.85 + inc * 0.75, self_time * 0.9);
 
         if (movestogo == 1) time_amt = self_time * 0.9;
-        else time_amt *= (0.6 + 0.4 * pts);
+        else time_amt *= (0.7 + 0.3 * pts);
 
         goto update;
     }

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -67,7 +67,7 @@ double position_time_scale(Position& position) {
 void time_handler(Engine& engine, double self_time, double inc, double movetime, long movestogo) {
     double time_amt;
 
-    double movestogo_ratio = movestogo == 0 ? 0 : std::clamp(std::atan((movestogo + 14) / 18.0), 0.75, 1.05);
+    double movestogo_ratio = movestogo == 0 ? 0 : std::clamp(std::atan((movestogo + 14) / 18.0), 0.75, 0.9);
 
     Position& position = engine.thread_states[0].position;
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -2,6 +2,7 @@
 // Created by Alexander Tian on 4/16/24.
 //
 
+#include <cmath>
 #include "timeman.h"
 
 double position_time_scale(Position& position) {
@@ -66,6 +67,8 @@ double position_time_scale(Position& position) {
 void time_handler(Engine& engine, double self_time, double inc, double movetime, long movestogo) {
     double time_amt;
 
+    double movestogo_ratio = movestogo == 0 ? 0 : std::clamp(std::asin((movestogo + 14) / 18.0), 0.75, 1.05);
+
     Position& position = engine.thread_states[0].position;
 
     double pts = position_time_scale(position);
@@ -87,10 +90,10 @@ void time_handler(Engine& engine, double self_time, double inc, double movetime,
     }
 
     if (movestogo > 0 && inc == 0) {
-        time_amt = self_time * 0.95 / static_cast<double>(movestogo);
-        if (time_amt > self_time * 0.95) time_amt = self_time * 0.95;
+        time_amt = self_time * movestogo_ratio / static_cast<double>(movestogo);
+        if (time_amt > self_time * 0.9) time_amt = self_time * 0.9;
 
-        if (movestogo == 1) time_amt = self_time;
+        if (movestogo == 1) time_amt = self_time * 0.9;
         else time_amt *= (0.6 + 0.4 * pts);
 
         goto update;
@@ -103,10 +106,10 @@ void time_handler(Engine& engine, double self_time, double inc, double movetime,
     }
 
     if (movestogo > 0 && inc > 0) {
-        time_amt = self_time * 0.95 / static_cast<double>(movestogo) + inc * 0.75;
-        if (time_amt > self_time * 0.95) time_amt = std::min(self_time * 0.85 + inc * 0.75, self_time * 0.95);
+        time_amt = self_time * movestogo_ratio / static_cast<double>(movestogo) + inc * 0.75;
+        if (time_amt > self_time * 0.9) time_amt = std::min(self_time * 0.85 + inc * 0.75, self_time * 0.9);
 
-        if (movestogo == 1) time_amt = self_time;
+        if (movestogo == 1) time_amt = self_time * 0.9;
         else time_amt *= (0.6 + 0.4 * pts);
 
         goto update;
@@ -131,6 +134,6 @@ update:
         engine.hard_time_limit = static_cast<uint64_t>(time_amt);
     }
 
-    std::cout << time_amt << " " << engine.soft_time_limit << " " << engine.hard_time_limit << std::endl;
+    // std::cout << time_amt << " " << engine.soft_time_limit << " " << engine.hard_time_limit << std::endl;
 }
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -64,7 +64,6 @@ double position_time_scale(Position& position) {
 
 
 void time_handler(Engine& engine, double self_time, double inc, double movetime, long movestogo) {
-    double rate = 20;
     double time_amt;
 
     Position& position = engine.thread_states[0].position;

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -1,0 +1,130 @@
+//
+// Created by Alexander Tian on 4/16/24.
+//
+
+#include "timeman.h"
+
+double position_time_scale(Position& position) {
+
+    /*
+     * We want to scale time based on the position and phase of the game.
+     * We should aim to use the most time out of the opening in the complex middle-game.
+     *
+     * A simple way to calculate the phase of the game is to give a score for each piece and sum up the total score
+     * that is calculated for each piece.
+     *
+     * We also consider the number of pawns on the lower ranks of the board.
+     */
+
+    int phase_scores[6] = {1, 3, 3, 7, 15, 0};
+
+    int max_score = 2 * (8 * phase_scores[0] + 2 * phase_scores[1] + 2 * phase_scores[2] + 2 * phase_scores[3] + phase_scores[4]);
+    int current_score = 0;
+
+    for (int piece = 0; piece < 12; piece++) {
+        current_score += popcount(position.pieces[piece]) * phase_scores[piece % 6];
+    }
+
+    int low_rank_pawns = 0;
+
+    BITBOARD white_pawns = position.pieces[WHITE_PAWN];
+    while (white_pawns) {
+        Square square = poplsb(white_pawns);
+        Rank rank = rank_of(square);
+
+        if (rank <= 2) low_rank_pawns++;
+    }
+
+    BITBOARD black_pawns = position.pieces[BLACK_PAWN];
+    while (black_pawns) {
+        Square square = poplsb(black_pawns);
+        Rank rank = rank_of(square);
+
+        if (rank >= 5) low_rank_pawns++;
+    }
+
+    double phase_ratio = static_cast<double>(current_score) / max_score;
+
+    // std::cout << current_score << " " << max_score << " " << phase_ratio << " " << low_rank_pawns << std::endl;
+
+    // Little material on the board
+    if (phase_ratio <= 0.1) return 0.2;
+
+    if (low_rank_pawns <= 4) return 0.1 + 0.6 * phase_ratio;
+
+    if (low_rank_pawns <= 8) return 0.3 + 0.7 * phase_ratio;
+
+    // Only two pawns are on "higher ranks", likely to be in the early opening.
+    if (low_rank_pawns >= 14) return 0.3 + 0.3 * phase_ratio;
+
+    if (low_rank_pawns >= 10) return 0.4 + 0.5 * phase_ratio;
+
+    return 0.6 + 0.6 * phase_ratio;
+}
+
+
+void time_handler(Engine& engine, double self_time, double inc, double movetime, long movestogo) {
+    double rate = 20;
+    double time_amt;
+
+    Position& position = engine.thread_states[0].position;
+
+    double pts = position_time_scale(position);
+
+    if (movetime > 0) {
+        time_amt = movetime * 0.9;
+        goto update;
+    }
+
+    if (self_time == 0) {
+        time_amt = 100;
+        goto update;
+    }
+
+    if (movestogo == 0 && inc == 0) {
+        time_amt = self_time / 24;
+        time_amt *= (0.8 + 0.2 * pts);
+        goto update;
+    }
+
+    if (movestogo > 0 && inc == 0) {
+        time_amt = self_time * 0.9 / static_cast<double>(movestogo);
+        if (time_amt > self_time * 0.9) time_amt = self_time * 0.95;
+
+        time_amt *= (0.6 + 0.4 * pts);
+        goto update;
+    }
+
+    if (inc > 0 && movestogo == 0) {
+        time_amt = self_time / 20 + inc * 0.75;
+        time_amt *= (0.7 + 0.3 * pts);
+        goto update;
+    }
+
+    if (movestogo > 0 && inc > 0) {
+        time_amt = self_time * 0.9 / static_cast<double>(movestogo) + inc * 0.75;
+        if (time_amt > self_time * 0.9) time_amt = self_time * 0.85 + inc * 0.75;
+
+        time_amt *= (0.6 + 0.4 * pts);
+        goto update;
+    }
+
+    time_amt = 100;
+
+update:
+    engine.hard_time_limit = std::max(static_cast<uint64_t>(time_amt),
+                                      static_cast<uint64_t>(time_amt * 2.64) - engine.move_overhead);
+
+    engine.soft_time_limit = static_cast<uint64_t>(time_amt * 0.76);
+
+    if (engine.hard_time_limit > static_cast<uint64_t>(self_time * 0.8) && self_time > 0) {
+        engine.hard_time_limit = static_cast<uint64_t>(self_time * 0.8);
+    }
+
+    if (engine.hard_time_limit > static_cast<uint64_t>(movetime) && movetime != 0.0) {
+        engine.hard_time_limit = static_cast<uint64_t>(time_amt);
+    }
+
+    std::cout << engine.soft_time_limit << " " << engine.hard_time_limit << std::endl;
+}
+

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -1,0 +1,15 @@
+//
+// Created by Alexander Tian on 4/16/24.
+//
+
+#ifndef ALTAIRCHESSENGINE_TIMEMAN_H
+#define ALTAIRCHESSENGINE_TIMEMAN_H
+
+#endif //ALTAIRCHESSENGINE_TIMEMAN_H
+
+#include "position.h"
+#include "search.h"
+
+double position_time_scale(Position& position);
+
+void time_handler(Engine& engine, double self_time, double inc, double movetime, long movestogo);

--- a/src/uci.h
+++ b/src/uci.h
@@ -26,7 +26,6 @@ public:
     void parse_position();
     void parse_go();
     void uci_loop();
-    void time_handler(double self_time, double inc, double movetime, long movestogo) const;
 };
 
 


### PR DESCRIPTION
Revamped Altair's time management.

STC:
```
Elo   | 5.53 +- 4.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9430 W: 2325 L: 2175 D: 4930
Penta | [66, 1020, 2401, 1154, 74]
https://chess.swehosting.se/test/6143/
```

LTC:
```
Elo   | 9.22 +- 6.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4446 W: 1088 L: 970 D: 2388
Penta | [10, 445, 1202, 549, 17]
https://chess.swehosting.se/test/6148/
```

Cyclic TM:
```
Elo   | -2.39 +- 4.60 (95%)
SPRT  | 40/15.0+0.00s Threads=1 Hash=32MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10026 W: 2268 L: 2337 D: 5421
Penta | [49, 1195, 2580, 1154, 35]
https://chess.swehosting.se/test/6167/
```

Although Cyclic TM did not gain, it had relatively smaller losses compared to the gains of STC and LTC, and is relatively unimportant in general.