### PR TITLE
qsearch TT eval

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -218,7 +218,7 @@ public:
     void record_tt_entry(int thread_id, HASH_TYPE hash_key, SCORE_TYPE score, short tt_flag, Move move, PLY_TYPE depth,
                          SCORE_TYPE static_eval, bool pv_node);
     short probe_tt_entry_q(int thread_id, HASH_TYPE hash_key, SCORE_TYPE alpha, SCORE_TYPE beta,
-                           SCORE_TYPE& return_score, Move& tt_move);
+                           TT_Entry& return_entry);
     void record_tt_entry_q(int thread_id, HASH_TYPE hash_key, SCORE_TYPE score, short tt_flag, Move move,
                            SCORE_TYPE static_eval);
     SCORE_TYPE probe_tt_evaluation(HASH_TYPE hash_key);


### PR DESCRIPTION
Elo   | 3.91 +- 3.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15654 W: 3901 L: 3725 D: 8028
Penta | [138, 1764, 3846, 1942, 137]
https://chess.swehosting.se/test/7002/