### PR TITLE
Pch

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -12,8 +12,8 @@
 
 #include "incbin.h"
 
-INCBIN(nnue, "src/ceres-net.bin");
-// INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/ceres-net.bin");
+// INCBIN(nnue, "src/ceres-net.bin");
+INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/ceres-net.bin");
 
 const NNUE_Params &original_nnue_parameters = *reinterpret_cast<const NNUE_Params *>(gnnueData);
 const NNUE_Params nnue_parameters = get_nnue_parameters();

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -12,8 +12,8 @@
 
 #include "incbin.h"
 
-// INCBIN(nnue, "src/ceres-net.bin");
-INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/ceres-net.bin");
+INCBIN(nnue, "src/ceres-net.bin");
+// INCBIN(nnue, "/Users/alexandertian/CLionProjects/Altair/src/ceres-net.bin");
 
 const NNUE_Params &original_nnue_parameters = *reinterpret_cast<const NNUE_Params *>(gnnueData);
 const NNUE_Params nnue_parameters = get_nnue_parameters();

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -119,7 +119,6 @@ void Position::compute_hash_key() {
 
     if (side) {
         hash_key ^= ZobristHashKeys.side_hash_key;
-        pawn_hash_key ^= ZobristHashKeys.side_hash_key;
     }
 }
 
@@ -757,7 +756,6 @@ bool Position::make_move(Move move, State& state, PLY_TYPE& fifty_move) {
     hash_key ^= ZobristHashKeys.castle_hash_keys[castle_ability_bits];
 
     hash_key ^= ZobristHashKeys.side_hash_key;
-    pawn_hash_key ^= ZobristHashKeys.side_hash_key;
     side = ~side;
 
     BITBOARD temp_our_pieces = our_pieces;

--- a/src/search.h
+++ b/src/search.h
@@ -13,6 +13,12 @@
 
 constexpr double learning_rate = 0.002;
 
+constexpr int correction_history_grain = 256;
+constexpr int correction_history_weight_scale = 256;
+constexpr int correction_history_size = 16384;
+constexpr int correction_history_max = correction_history_grain * 32;
+
+
 struct TT_Entry {
     HASH_TYPE key = 0;
     SCORE_TYPE score = SCORE_NONE;
@@ -136,6 +142,7 @@ public:
     SCORE_TYPE history_moves[12][64]{}; // piece | target_square
     SCORE_TYPE capture_history[2][12][12][64]{};
     SCORE_TYPE continuation_history[12][64][12][64]{};
+    SCORE_TYPE correction_history[2][correction_history_size]{};
 
     HASH_TYPE repetition_table[TOTAL_MAX_DEPTH + 512] = {0};
 
@@ -150,6 +157,9 @@ public:
     bool detect_repetition_3();
 
     SCORE_TYPE& get_continuation_history_entry(InformativeMove last_move, InformativeMove informative_move);
+
+    void update_correction_history_score(PLY_TYPE depth, SCORE_TYPE diff);
+    int correct_evaluation(SCORE_TYPE evaluation);
 
     inline void reset_generators() {
         for (int ply = 0; ply < static_cast<int>(generators.size()); ply++) {


### PR DESCRIPTION
Pawn key indexed correction history

```
Elo   | 3.52 +- 2.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18246 W: 4509 L: 4324 D: 9413
Penta | [130, 2129, 4441, 2272, 151]
https://chess.swehosting.se/test/7063/
```