### PR TITLE
Fix pawn key

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -570,7 +570,7 @@ bool Position::make_move(Move move, State& state, PLY_TYPE& fifty_move) {
     MoveType move_type = move.type();
 
     PieceType selected_type = get_piece_type(selected, side);
-    PieceType occupied_type = occupied == EMPTY ? NONE : get_piece_type(selected, ~side);
+    PieceType occupied_type = occupied == EMPTY ? NONE : get_piece_type(occupied, ~side);
 
     state.move = InformativeMove(move, selected, occupied);
 


### PR DESCRIPTION
```
Elo   | -0.61 +- 3.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.12 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 10304 W: 2417 L: 2435 D: 5452
Penta | [34, 1157, 2773, 1169, 19]
https://chess.swehosting.se/test/7091/
```
Merged for being relatively equal at high game count while being a bug that is imperative to fix.