### PR TITLE
Qsearch pch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -439,20 +439,6 @@ SCORE_TYPE qsearch(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             return tt_value;
         }
 
-        if (tt_move == NO_MOVE || tt_move.is_capture(position) || tt_move.type() == MOVE_TYPE_EP ||
-            !position.is_pseudo_legal(tt_move)) {
-            return eval;
-        }
-
-        bool attempt = position.make_move<NNUE>(tt_move, position.state_stack[thread_state.search_ply], thread_state.fifty_move);
-
-        if (attempt) {
-            eval = engine.probe_tt_evaluation(position.hash_key);
-            if (eval == NO_EVALUATION) eval = engine.evaluate<NNUE>(thread_id);
-        }
-
-        position.undo_move<NNUE>(tt_move, position.state_stack[thread_state.search_ply], thread_state.fifty_move);
-
         return eval;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -437,6 +437,20 @@ SCORE_TYPE qsearch(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             return tt_value;
         }
 
+        if (tt_move == NO_MOVE || tt_move.is_capture(position) || tt_move.type() == MOVE_TYPE_EP ||
+            !position.is_pseudo_legal(tt_move)) {
+            return eval;
+        }
+
+        bool attempt = position.make_move<NNUE>(tt_move, position.state_stack[thread_state.search_ply], thread_state.fifty_move);
+
+        if (attempt) {
+            eval = engine.probe_tt_evaluation(position.hash_key);
+            if (eval == NO_EVALUATION) eval = engine.evaluate<NNUE>(thread_id);
+        }
+
+        position.undo_move<NNUE>(tt_move, position.state_stack[thread_state.search_ply], thread_state.fifty_move);
+
         return eval;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -420,8 +420,10 @@ SCORE_TYPE qsearch(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
     }
 
     // Get the static evaluation of the position
-    SCORE_TYPE eval = engine.probe_tt_evaluation(position.hash_key);
-    if (eval == NO_EVALUATION) eval = engine.evaluate<NNUE>(thread_id);
+    SCORE_TYPE raw_eval = engine.probe_tt_evaluation(position.hash_key);
+    if (raw_eval == NO_EVALUATION) raw_eval = engine.evaluate<NNUE>(thread_id);
+
+    SCORE_TYPE eval = thread_state.correct_evaluation(raw_eval);
 
     // Return the evaluation if we have reached a stand-pat, or we have reached the maximum depth
     if (depth == 0 || eval >= beta) {
@@ -540,7 +542,7 @@ SCORE_TYPE qsearch(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
 #endif
 
                     engine.record_tt_entry_q(thread_id, position.hash_key, best_score, HASH_FLAG_LOWER, best_move,
-                                             position.state_stack[thread_state.search_ply].static_eval);
+                                             raw_eval);
                     return best_score;
                 }
             }
@@ -549,7 +551,7 @@ SCORE_TYPE qsearch(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
     }
 
     engine.record_tt_entry_q(thread_id, position.hash_key, best_score, tt_hash_flag, best_move,
-                             position.state_stack[thread_state.search_ply].static_eval);
+                             raw_eval);
 
     return best_score;
 }


### PR DESCRIPTION
```
Elo   | 3.51 +- 2.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18980 W: 4776 L: 4584 D: 9620
Penta | [179, 2173, 4589, 2375, 174]
https://chess.swehosting.se/test/7139/
```