### PR TITLE
Squared depth correction history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -144,7 +144,7 @@ SCORE_TYPE& Thread_State::get_continuation_history_entry(InformativeMove last_mo
 void Thread_State::update_correction_history_score(PLY_TYPE depth, SCORE_TYPE diff) {
     auto& c_hist_entry = correction_history[position.side][position.pawn_hash_key % correction_history_size];
     int scaled_diff = diff * correction_history_grain;
-    int new_weight = std::min(1 + depth, 16);
+    int new_weight = std::min((1 + depth) * (1 + depth), 144);
 
     c_hist_entry = (c_hist_entry * (correction_history_weight_scale - new_weight) + scaled_diff * new_weight) /
                     correction_history_weight_scale;

--- a/src/search.h
+++ b/src/search.h
@@ -19,9 +19,9 @@ constexpr int max_cont_history  = 10368;
 constexpr int max_noisy_history = 10368;
 
 constexpr int correction_history_grain = 256;
-constexpr int correction_history_weight_scale = 256;
+constexpr int correction_history_weight_scale = 1024;
 constexpr int correction_history_size = 16384;
-constexpr int correction_history_max = correction_history_grain * 32;
+constexpr int correction_history_max = correction_history_grain * 64;
 
 
 struct TT_Entry {


### PR DESCRIPTION
```
Elo   | 2.70 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 29710 W: 7330 L: 7099 D: 15281
Penta | [228, 3452, 7241, 3729, 205]
https://chess.swehosting.se/test/7145/
```