### PR TITLE
multicut use return eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -861,8 +861,8 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             }
 
             // Multi-cut Pruning
-            else if (singular_beta >= beta) {
-                return singular_beta;
+            else if (return_eval >= beta) {
+                return return_eval;
             }
 
             else if (tt_entry.score >= beta || tt_entry.score <= alpha) {


### PR DESCRIPTION
```
Elo   | 3.95 +- 3.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15674 W: 3943 L: 3765 D: 7966
Penta | [120, 1865, 3705, 2011, 136]
https://chess.swehosting.se/test/7169/
```
