### PR TITLE
Fix NEON SIMD

### DIFF
--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -47,7 +47,7 @@ SCORE_TYPE NNUE_State::evaluate(Position& position, Color color) {
     const int output_bucket = (popcount(position.all_pieces) - 2) / MATERIAL_OUTPUT_BUCKET_DIVISOR;
 
     const auto flatten = []() {
-        if constexpr (SIMD::ARCH == SIMD::Arch::AUTO || SIMD::ARCH == SIMD::Arch::NEON) return screlu_flatten;
+        if constexpr (SIMD::ARCH == SIMD::Arch::AUTO) return screlu_flatten;
         return screlu_flatten_simd;
     }();
 

--- a/src/simd.h
+++ b/src/simd.h
@@ -114,9 +114,9 @@ namespace SIMD {
         return _mm256_madd_epi16(vec1, vec2);
 #elif defined(__ARM_NEON)
         int32x4_t low_product  = vmull_s16(vget_low_s16 (vec1), vget_low_s16 (vec2));
-        int32x4_t high_product = vmull_s16(vget_high_s16(vec1), vget_high_s16(vec2));
+        int32x4_t high_product = vmull_high_s16(vec1, vec2);
 
-        return vaddq_s32(low_product, high_product);
+        return vpaddq_s32(low_product, high_product);
 #else
         return 0;
 #endif


### PR DESCRIPTION
Utilize NEON SIMD instead of auto vectorization now, after fixing instructions for `vec_int16_madd_int32`.

On my mac m1 air speedup is around:
`1.2Mnps` --> `1.3Mnps` 

From previous NEON SIMD to fixed NEON SIMD:
`0.9Mnps` --> `1.3Mnps`

The fix is most directly contributed by using `vpaddq_s32` which performs the horizontal addition, instead of the incorrect `vaddq_s32` which performs vertical, element-wise addition in `vec_int16_madd_int32`.