### PR TITLE
self chosen values

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -59,22 +59,22 @@ struct SearchParameters {
 
     //                             v   min  max step        name
     T LMR_divisor_quiet       = { 230, 150, 230, 20, "LMR_divisor_quiet"};
-    T LMR_base_quiet          = { 112, 100, 170, 20, "LMR_base_quiet"};
-    T LMR_history_divisor     = {10485, 4000, 14000, 1000, "LMR_history_divisor"};
+    T LMR_base_quiet          = { 115, 100, 170, 20, "LMR_base_quiet"};
+    T LMR_history_divisor     = {10000, 4000, 14000, 1000, "LMR_history_divisor"};
 
-    T RFP_depth               = {   5,   5,  11,   2, "RFP_depth"};
-    T RFP_margin              = { 108,  50, 200,  30, "RFP_margin"};
+    T RFP_depth               = {   7,   5,  11,   2, "RFP_depth"};
+    T RFP_margin              = { 110,  50, 200,  30, "RFP_margin"};
 
     T LMP_depth               = {   4,   1,   5,   1, "LMP_depth"};
     T LMP_margin              = {  10,   5,  15,   1, "LMP_margin"};
 
     T history_pruning_depth   = {  10,   3,  20,   2, "history_pruning_depth"};
-    T history_pruning_divisor = {9588, 1000, 20000, 1800, "history_pruning_divisor"};
+    T history_pruning_divisor = {9600, 1000, 20000, 1800, "history_pruning_divisor"};
 
     T NMP_depth               = {   1,   0,   4,   1, "NMP_depth"};
     T NMP_base                = {   5,   1,   5,   1, "NMP_base"};
     T NMP_depth_divisor       = {   4,   2,   6,   1, "NMP_depth_divisor"};
-    T NMP_eval_divisor        = { 398, 100, 400,  40, "NMP_eval_divisor"};
+    T NMP_eval_divisor        = { 400, 100, 400,  40, "NMP_eval_divisor"};
     T NMP_condition_base      = { 128,   0, 200,  10, "NMP_condition_base"};
     T NMP_condition_depth     = {  11,   0,  20,   2, "NMP_condition_depth"};
     T NMP_condition_improving = {   3,   0,  20,   2, "NMP_condition_improving"};
@@ -83,27 +83,27 @@ struct SearchParameters {
     T SEE_noisy_depth         = {   0,   0,   4,   1, "SEE_noisy_depth"};
     T SEE_pv_depth            = {   5,   0,   5,   1, "SEE_pv_depth"};
     T SEE_base_moves          = {   4,   1,   5,   1, "SEE_base_moves"};
-    T SEE_base_history        = {4726, 1000, 10000, 1000, "SEE_base_history"};
-    T SEE_quiet_multiplier    = {  34,  20,  80,   8, "SEE_quiet_multiplier"};
-    T SEE_noisy_multiplier    = {  83,  50, 150,  10, "SEE_noisy_multiplier"};
+    T SEE_base_history        = {5800, 1000, 10000, 1000, "SEE_base_history"};
+    T SEE_quiet_multiplier    = {  40,  20,  80,   8, "SEE_quiet_multiplier"};
+    T SEE_noisy_multiplier    = {  85,  50, 150,  10, "SEE_noisy_multiplier"};
 
     T SEE_MO_threshold        = {  85,  60, 120,   5, "SEE_MO_threshold"};
 
     T LMP_margin_quiet        = {   2,   1,   4,   1, "LMP_margin_quiet"};
 
     T FP_depth                = {   7,   1,   8,   1, "FP_depth"};
-    T FP_multiplier           = { 168,  80, 220,  20, "FP_multiplier"};
-    T FP_margin               = {  71,  40, 150,  20, "FP_margin"};
+    T FP_multiplier           = { 170,  80, 220,  20, "FP_multiplier"};
+    T FP_margin               = {  70,  40, 150,  20, "FP_margin"};
 
-    T QSEE_base               = {  72,  40, 200,  10, "QSEE_base"};
+    T QSEE_base               = {  70,  40, 200,  10, "QSEE_base"};
 
     T IIR_base_depth          = {   4,   1,   8,   1, "IIR_base_depth"};
 
-    T SE_base_depth           = {   7,   3,   9,   1, "SE_base_depth"};
-    T SE_dext_margin          = {  13,   6,  25,   2, "SE_dext_margin"};
-    T SE_dext_limit           = {   6,   4,  12,   1, "SE_dext_limit"};
+    T SE_base_depth           = {   6,   3,   9,   1, "SE_base_depth"};
+    T SE_dext_margin          = {  12,   6,  25,   2, "SE_dext_margin"};
+    T SE_dext_limit           = {   7,   4,  12,   1, "SE_dext_limit"};
 
-    T deeper_margin           = {  83,  50, 130,   8, "deeper_margin"};
+    T deeper_margin           = {  80,  50, 130,   8, "deeper_margin"};
 
     T ASP_beta_scaler         = {   5,   1,  10,   1, "ASP_beta_scaler"};
     T ASP_alpha_scaler        = {   3,   1,  10,   1, "ASP_alpha_scaler"};
@@ -111,12 +111,12 @@ struct SearchParameters {
     T ASP_delta_divisor       = {   5,   1,  10,   1, "ASP_delta_divisor"};
     T ASP_delta_min           = {   9,   4,  15,   1, "ASP_delta_min"};
 
-    T H_max_quiet             = {  9037, 5000, 18000, 600, "H_max_quiet"};
-    T H_max_noisy             = { 11761, 5000, 18000, 600, "H_max_noisy"};
-    T H_max_cont              = { 10908, 5000, 18000, 600, "H_max_cont"};
+    T H_max_quiet             = {  9000, 5000, 18000, 600, "H_max_quiet"};
+    T H_max_noisy             = { 12000, 5000, 18000, 600, "H_max_noisy"};
+    T H_max_cont              = { 11000, 5000, 18000, 600, "H_max_cont"};
 
     T TM_node_margin          = { 135, 100, 200,   8, "TM_node_margin"};
-    T TM_node_scalar          = { 179, 140, 200,   6, "TM_node_scalar"};
+    T TM_node_scalar          = { 180, 140, 200,   6, "TM_node_scalar"};
 
     T TM_score_min            = { 276, 100, 500,  30, "TM_score_min"};
     T TM_score_max            = { 136,  50, 400,  30, "TM_score_max"};


### PR DESCRIPTION
Just another example that SPSA is not perfect. Values I chose myself gain more at LTC than a week+ long tune of ~100,000 LTC games.

```
Elo   | 4.50 +- 3.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11110 W: 2719 L: 2575 D: 5816
Penta | [26, 1232, 2905, 1356, 36]
https://chess.swehosting.se/test/7421/
```
Bench: 8014754