### PR TITLE
depth bonus to history

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1033,7 +1033,8 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
                 tt_hash_flag = HASH_FLAG_EXACT;
 
                 // History Heuristic for move ordering
-                SCORE_TYPE bonus = depth * (depth + 1 + null_search + pv_node + improving) - 1;
+                int depth_adjusted = depth + (alpha >= eval);
+                SCORE_TYPE bonus = depth_adjusted * (depth_adjusted + 1 + null_search + pv_node + improving) - 1;
 
                 update_histories(thread_state, informative_move, last_moves, quiet, winning_capture, bonus);
 


### PR DESCRIPTION
```
Elo   | 5.61 +- 3.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9422 W: 2323 L: 2171 D: 4928
Penta | [73, 1044, 2330, 1186, 78]
https://chess.swehosting.se/test/7457/
```
Bench: 7467743