### PR TITLE
Remove Null Search Reduction

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1001,9 +1001,6 @@ SCORE_TYPE negamax(Engine& engine, SCORE_TYPE alpha, SCORE_TYPE beta, PLY_TYPE d
             // Scale reductions based on how many moves have already raised alpha
             reduction += static_cast<int>(static_cast<double>(alpha_raised_count) * (0.5 + 0.5 * tt_move_noisy));
 
-            // My idea that in a null move search you can be more aggressive with LMR
-            reduction += null_search;
-
             // Reduce more on cutnodes
             reduction += cutnode;
 


### PR DESCRIPTION
```
Elo   | 2.98 +- 2.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23292 W: 5821 L: 5621 D: 11850
Penta | [148, 2629, 5913, 2787, 169]
https://chess.swehosting.se/test/9149/
```
Bench: 7316661